### PR TITLE
Only translate label if it starts with 'LLL'

### DIFF
--- a/Classes/Domain/Model/Dto/ListItem.php
+++ b/Classes/Domain/Model/Dto/ListItem.php
@@ -54,7 +54,8 @@ final class ListItem
         if (isset($CTypeLabels[$cType])) {
             $label = $CTypeLabels[$cType];
         }
-        return LocalizationUtility::translate($label);
+
+        return str_starts_with($label, 'LLL') ? LocalizationUtility::translate($label) : $label;
     }
 
     public function getTitle(): string


### PR DESCRIPTION
Translating a label without the LLL prefix throws an error in the widget:

![Bildschirmfoto 2024-10-18 um 16 28 21](https://github.com/user-attachments/assets/41157b97-2609-4a97-9c0c-bdf586ca4140)

This happens because the extension tries to translate the content element title which fails if it doesn't start with "LLL"
since it then needs the additional parameter "$extensionName" which isn't being passed:

![Bildschirmfoto 2024-10-18 um 16 28 26](https://github.com/user-attachments/assets/4cbb1ac9-1302-40bd-ba2a-e11cdcd85aa4)
