### PR TITLE
fix: conditionally render widget title for TYPO3 versions below 13

### DIFF
--- a/Resources/Private/Templates/List.html
+++ b/Resources/Private/Templates/List.html
@@ -3,9 +3,11 @@
     xmlns:core="http://typo3.org/ns/TYPO3/CMS/Core/ViewHelpers"
     data-namespace-typo3-fluid="true">
 
-<div class="widget-content-title d-flex" style="gap:10px;">
-    <span><f:translate key="widgets.recentUpdates.title" extensionName="XimaTypo3RecentUpdates"/></span>
-</div>
+<f:if condition="{version} < 13">
+    <div class="widget-content-title d-flex" style="gap:10px;">
+        <span><f:translate key="widgets.recentUpdates.title" extensionName="XimaTypo3RecentUpdates"/></span>
+    </div>
+</f:if>
 <div class="widget-content-main x--recent-updates-widget--main" style="--mask: linear-gradient(to bottom, rgba(0, 0, 0, 1) 0, rgba(0, 0, 0, 1) 90%, rgba(0, 0, 0, 0) 95%, rgba(0, 0, 0, 0) 0) 100% 90% / 100% 100% repeat-x;-webkit-mask: var(--mask);mask: var(--mask);">
     <f:if condition="{records}">
         <f:then>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The widget title is now displayed only for versions earlier than 13.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->