### PR TITLE
fix: guard missing keys in sys_log log_data

### DIFF
--- a/Classes/Domain/Model/Dto/ListItem.php
+++ b/Classes/Domain/Model/Dto/ListItem.php
@@ -39,7 +39,7 @@ final class ListItem
     {
         $item = new ListItem();
         $item->log = $sysLogRow;
-        $logData = unserialize($item->log['log_data']);
+        $logData = unserialize($item->log['log_data'], ['allowed_classes' => false]);
         $item->log['log_data'] = is_array($logData) ? $logData : [];
         $item->log['title'] = $item->log['log_data'][0] ?? RecordUtility::getRecordTitle($item->log['log_data']['table'] ?? null, $item->log['log_data']['uid'] ?? null);
         return $item;

--- a/Classes/Domain/Model/Dto/ListItem.php
+++ b/Classes/Domain/Model/Dto/ListItem.php
@@ -39,7 +39,7 @@ final class ListItem
     {
         $item = new ListItem();
         $item->log = $sysLogRow;
-        $logData = unserialize($item->log['log_data'], ['allowed_classes' => false]);
+        $logData = @unserialize($item->log['log_data'], ['allowed_classes' => false]);
         $item->log['log_data'] = is_array($logData) ? $logData : [];
         $item->log['title'] = $item->log['log_data'][0] ?? RecordUtility::getRecordTitle($item->log['log_data']['table'] ?? null, $item->log['log_data']['uid'] ?? null);
         return $item;

--- a/Classes/Domain/Model/Dto/ListItem.php
+++ b/Classes/Domain/Model/Dto/ListItem.php
@@ -39,8 +39,9 @@ final class ListItem
     {
         $item = new ListItem();
         $item->log = $sysLogRow;
-        $item->log['log_data'] = unserialize($item->log['log_data']);
-        $item->log['title'] = $item->log['log_data'][0] ?? RecordUtility::getRecordTitle($item->log['log_data']['table'], $item->log['log_data']['uid']);
+        $logData = unserialize($item->log['log_data']);
+        $item->log['log_data'] = is_array($logData) ? $logData : [];
+        $item->log['title'] = $item->log['log_data'][0] ?? RecordUtility::getRecordTitle($item->log['log_data']['table'] ?? null, $item->log['log_data']['uid'] ?? null);
         return $item;
     }
 
@@ -48,8 +49,9 @@ final class ListItem
     {
         $item = new ListItem();
         $item->log = $sysLogRow;
-        $item->log['log_data'] = json_decode($item->log['log_data'], true);
-        $item->log['title'] = $item->log['log_data']['title'] ?? RecordUtility::getRecordTitle($item->log['log_data']['table'], $item->log['log_data']['uid']);
+        $logData = json_decode($item->log['log_data'], true);
+        $item->log['log_data'] = is_array($logData) ? $logData : [];
+        $item->log['title'] = $item->log['log_data']['title'] ?? RecordUtility::getRecordTitle($item->log['log_data']['table'] ?? null, $item->log['log_data']['uid'] ?? null);
         return $item;
     }
 

--- a/Tests/Unit/Domain/Model/Dto/ListItemTest.php
+++ b/Tests/Unit/Domain/Model/Dto/ListItemTest.php
@@ -72,6 +72,52 @@ class ListItemTest extends TestCase
         self::assertIsArray($listItem->log['log_data']);
     }
 
+    public function testCreateFromV12LogWithoutTitleAndRecordReference(): void
+    {
+        $logData = [
+            'uid' => 1,
+            'updated' => 1234567890,
+            'tablename' => 'tt_content',
+            'details' => 'Test details',
+            'log_data' => '{"history":"12"}',
+            'cType' => 'text',
+        ];
+
+        $listItem = ListItem::createFromV12Log($logData);
+
+        self::assertSame('', $listItem->log['title']);
+    }
+
+    public function testCreateFromV11LogWithoutTitleAndRecordReference(): void
+    {
+        $logData = [
+            'uid' => 1,
+            'updated' => 1234567890,
+            'tablename' => 'tt_content',
+            'details' => 'Test details',
+            'log_data' => serialize(['history' => '12']),
+            'cType' => 'text',
+        ];
+
+        $listItem = ListItem::createFromV11Log($logData);
+
+        self::assertSame('', $listItem->log['title']);
+    }
+
+    public function testCreateFromLogWithNonArrayLogData(): void
+    {
+        $logData = [
+            'uid' => 1,
+            'updated' => 1234567890,
+            'tablename' => 'tt_content',
+            'details' => 'Test details',
+            'cType' => 'text',
+        ];
+
+        self::assertSame([], ListItem::createFromV12Log(['log_data' => 'not json'] + $logData)->log['log_data']);
+        self::assertSame([], ListItem::createFromV11Log(['log_data' => serialize(false)] + $logData)->log['log_data']);
+    }
+
     public function testTruncate(): void
     {
         $shortString = 'Short text';

--- a/Tests/Unit/Domain/Model/Dto/ListItemTest.php
+++ b/Tests/Unit/Domain/Model/Dto/ListItemTest.php
@@ -118,6 +118,22 @@ class ListItemTest extends TestCase
         self::assertSame([], ListItem::createFromV11Log(['log_data' => serialize(false)] + $logData)->log['log_data']);
     }
 
+    public function testCreateFromV11LogWithMalformedSerializedDataDoesNotEmitDiagnostic(): void
+    {
+        $logData = [
+            'uid' => 1,
+            'updated' => 1234567890,
+            'tablename' => 'tt_content',
+            'details' => 'Test details',
+            'log_data' => 'a:2:{s:5:"table";s:10:"tt_content";',
+            'cType' => 'text',
+        ];
+
+        $listItem = ListItem::createFromV11Log($logData);
+
+        self::assertSame([], $listItem->log['log_data']);
+    }
+
     public function testTruncate(): void
     {
         $shortString = 'Short text';


### PR DESCRIPTION
Fixes #30

`ListItem::createFromV12Log()` and `createFromV11Log()` read `log_data['table']` and `log_data['uid']` unconditionally as the fallback arguments for the item title. A `sys_log` payload carrying neither a `title` nor a record reference therefore emits `Undefined array key "table"` / `"uid"` on every widget render. `RecordUtility::getRecordTitle()` is already nullable on both parameters and returns `''`, so the null defaults preserve the existing behaviour and only drop the warning.

The same two methods stored the raw result of `json_decode()` / `unserialize()`, so an undecodable payload left `log_data` as `null` or `false` and broke every later access on it (`getDetails()` calls `array_keys()` on it). Both now normalise to an array.

### Verification

Reverting `ListItem.php` and keeping the new tests reproduces the reported warnings verbatim:

```
1) Classes/Domain/Model/Dto/ListItem.php:52  Undefined array key "table"
2) Classes/Domain/Model/Dto/ListItem.php:52  Undefined array key "uid"
3) Classes/Domain/Model/Dto/ListItem.php:43  Undefined array key "table"
4) Classes/Domain/Model/Dto/ListItem.php:43  Undefined array key "uid"
5) Classes/Domain/Model/Dto/ListItem.php:52  Trying to access array offset on value of type null
Tests: 3, Assertions: 3, Failures: 1, Warnings: 5.
```

With the fix applied: `OK (33 tests, 57 assertions)`, PHPStan clean, php-cs-fixer clean apart from a pre-existing copyright-year drift affecting 18 files repo-wide (left untouched).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of log entries with missing, invalid, or incomplete data.
  * Prevented errors when record references are unavailable.
  * Ensured affected list items display an empty title when no title information exists.

* **Tests**
  * Added coverage for legacy and current log formats, including malformed data and missing record details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->