### PR TITLE
style: update copyright year to 2026

### DIFF
--- a/Classes/Configuration.php
+++ b/Classes/Configuration.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of the TYPO3 CMS extension "xima_typo3_recent_updates".
  *
- * Copyright (C) 2023-2025 Konrad Michalik <hej@konradmichalik.dev>
+ * Copyright (C) 2023-2026 Konrad Michalik <hej@konradmichalik.dev>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/Classes/Domain/Model/Dto/ListItem.php
+++ b/Classes/Domain/Model/Dto/ListItem.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the TYPO3 CMS extension "xima_typo3_recent_updates".
  *
- * Copyright (C) 2023-2025 Konrad Michalik <hej@konradmichalik.dev>
+ * Copyright (C) 2023-2026 Konrad Michalik <hej@konradmichalik.dev>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/Classes/Utility/RecordUtility.php
+++ b/Classes/Utility/RecordUtility.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of the TYPO3 CMS extension "xima_typo3_recent_updates".
  *
- * Copyright (C) 2023-2025 Konrad Michalik <hej@konradmichalik.dev>
+ * Copyright (C) 2023-2026 Konrad Michalik <hej@konradmichalik.dev>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/Classes/Utility/ViewFactoryHelper.php
+++ b/Classes/Utility/ViewFactoryHelper.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of the TYPO3 CMS extension "xima_typo3_recent_updates".
  *
- * Copyright (C) 2023-2025 Konrad Michalik <hej@konradmichalik.dev>
+ * Copyright (C) 2023-2026 Konrad Michalik <hej@konradmichalik.dev>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/Classes/ViewHelpers/TimeAgoViewHelper.php
+++ b/Classes/ViewHelpers/TimeAgoViewHelper.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of the TYPO3 CMS extension "xima_typo3_recent_updates".
  *
- * Copyright (C) 2023-2025 Konrad Michalik <hej@konradmichalik.dev>
+ * Copyright (C) 2023-2026 Konrad Michalik <hej@konradmichalik.dev>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/Classes/Widgets/Provider/RecentUpdatesDataProvider.php
+++ b/Classes/Widgets/Provider/RecentUpdatesDataProvider.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of the TYPO3 CMS extension "xima_typo3_recent_updates".
  *
- * Copyright (C) 2023-2025 Konrad Michalik <hej@konradmichalik.dev>
+ * Copyright (C) 2023-2026 Konrad Michalik <hej@konradmichalik.dev>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/Classes/Widgets/Provider/SysLogButtonProvider.php
+++ b/Classes/Widgets/Provider/SysLogButtonProvider.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of the TYPO3 CMS extension "xima_typo3_recent_updates".
  *
- * Copyright (C) 2023-2025 Konrad Michalik <hej@konradmichalik.dev>
+ * Copyright (C) 2023-2026 Konrad Michalik <hej@konradmichalik.dev>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/Classes/Widgets/RecentUpdates.php
+++ b/Classes/Widgets/RecentUpdates.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of the TYPO3 CMS extension "xima_typo3_recent_updates".
  *
- * Copyright (C) 2023-2025 Konrad Michalik <hej@konradmichalik.dev>
+ * Copyright (C) 2023-2026 Konrad Michalik <hej@konradmichalik.dev>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/Configuration/Icons.php
+++ b/Configuration/Icons.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of the TYPO3 CMS extension "xima_typo3_recent_updates".
  *
- * Copyright (C) 2023-2025 Konrad Michalik <hej@konradmichalik.dev>
+ * Copyright (C) 2023-2026 Konrad Michalik <hej@konradmichalik.dev>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/Tests/Unit/ConfigurationTest.php
+++ b/Tests/Unit/ConfigurationTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of the TYPO3 CMS extension "xima_typo3_recent_updates".
  *
- * Copyright (C) 2023-2025 Konrad Michalik <hej@konradmichalik.dev>
+ * Copyright (C) 2023-2026 Konrad Michalik <hej@konradmichalik.dev>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/Tests/Unit/Domain/Model/Dto/ListItemTest.php
+++ b/Tests/Unit/Domain/Model/Dto/ListItemTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of the TYPO3 CMS extension "xima_typo3_recent_updates".
  *
- * Copyright (C) 2023-2025 Konrad Michalik <hej@konradmichalik.dev>
+ * Copyright (C) 2023-2026 Konrad Michalik <hej@konradmichalik.dev>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/Tests/Unit/ViewHelpers/TimeAgoViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/TimeAgoViewHelperTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of the TYPO3 CMS extension "xima_typo3_recent_updates".
  *
- * Copyright (C) 2023-2025 Konrad Michalik <hej@konradmichalik.dev>
+ * Copyright (C) 2023-2026 Konrad Michalik <hej@konradmichalik.dev>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/Tests/Unit/Widgets/Provider/RecentUpdatesDataProviderTest.php
+++ b/Tests/Unit/Widgets/Provider/RecentUpdatesDataProviderTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of the TYPO3 CMS extension "xima_typo3_recent_updates".
  *
- * Copyright (C) 2023-2025 Konrad Michalik <hej@konradmichalik.dev>
+ * Copyright (C) 2023-2026 Konrad Michalik <hej@konradmichalik.dev>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/Tests/Unit/Widgets/RecentUpdatesTest.php
+++ b/Tests/Unit/Widgets/RecentUpdatesTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of the TYPO3 CMS extension "xima_typo3_recent_updates".
  *
- * Copyright (C) 2023-2025 Konrad Michalik <hej@konradmichalik.dev>
+ * Copyright (C) 2023-2026 Konrad Michalik <hej@konradmichalik.dev>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the TYPO3 CMS extension "xima_typo3_recent_updates".
  *
- * Copyright (C) 2023-2025 Konrad Michalik <hej@konradmichalik.dev>
+ * Copyright (C) 2023-2026 Konrad Michalik <hej@konradmichalik.dev>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/packaging_exclude.php
+++ b/packaging_exclude.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of the TYPO3 CMS extension "xima_typo3_recent_updates".
  *
- * Copyright (C) 2023-2025 Konrad Michalik <hej@konradmichalik.dev>
+ * Copyright (C) 2023-2026 Konrad Michalik <hej@konradmichalik.dev>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/php-cs-fixer.php
+++ b/php-cs-fixer.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of the TYPO3 CMS extension "xima_typo3_recent_updates".
  *
- * Copyright (C) 2023-2025 Konrad Michalik <hej@konradmichalik.dev>
+ * Copyright (C) 2023-2026 Konrad Michalik <hej@konradmichalik.dev>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/rector.php
+++ b/rector.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of the TYPO3 CMS extension "xima_typo3_recent_updates".
  *
- * Copyright (C) 2023-2025 Konrad Michalik <hej@konradmichalik.dev>
+ * Copyright (C) 2023-2026 Konrad Michalik <hej@konradmichalik.dev>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
The `header_comment` rule in `php-cs-fixer.php` derives the end year of the copyright header from the current date. The headers say `2023-2025`, so the `cgl` check fails on every run started after new year, in every branch, regardless of what the branch changes:

```
##[warning]Found violation(s) of type: header_comment
##[error]Process completed with exit code 1.
```

The last `cgl` run on `main` was 2025-12-22 and passed, because the year still matched then.

Applied with `composer fix:php` rather than by hand, so the result is exactly what the check compares against. The diff is one line per file across 18 files and contains nothing but the year:

```
- * Copyright (C) 2023-2025 Konrad Michalik <hej@konradmichalik.dev>
+ * Copyright (C) 2023-2026 Konrad Michalik <hej@konradmichalik.dev>
```

Verified locally: `php-cs-fixer --dry-run` finds 0 of 20 files to fix, PHPStan reports no errors, 33 tests pass.

Note that this recurs every January. Ending the cycle would mean changing the header template in `php-cs-fixer.php` to an open-ended year, which is a config decision and deliberately not part of this PR.
